### PR TITLE
Fix album info error in parser

### DIFF
--- a/get_1001_data.py
+++ b/get_1001_data.py
@@ -34,8 +34,8 @@ def get_albums(project_id):
                 'releaseDate': int(album['releaseDate']),
                 'global_rating': alb_dict['globalRating']
             }
+            albums_data.append(album_info)
         except Exception as e:
             logging.error(f"Failed to get album info for {album}: {e}")
-        albums_data.append(album_info)
     return albums_data
 

--- a/tests/test_get_1001_data.py
+++ b/tests/test_get_1001_data.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import types
+
+# Provide a minimal stub for the requests module used by get_1001_data
+sys.modules.setdefault('requests', types.ModuleType('requests'))
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import get_1001_data
+
+
+def test_get_albums_handles_missing_keys(monkeypatch):
+    sample_history = [
+        {"album": {
+            "spotifyId": "id1",
+            "artist": "Test Artist",
+            "name": "Test Name",
+            "genres": [],
+            "subGenres": [],
+            # missing 'releaseDate' key will cause exception
+        },
+         "globalRating": 4}
+    ]
+
+    def fake_get_project_stats(project_id):
+        return {"history": sample_history}
+
+    monkeypatch.setattr(get_1001_data, "get_project_stats", fake_get_project_stats)
+
+    albums = get_1001_data.get_albums("dummy")
+    # Because parsing failed, no albums should be returned
+    assert albums == []


### PR DESCRIPTION
## Summary
- handle errors when building album info
- add regression test for album info parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841781461bc83238d0a79e362bd6f6a